### PR TITLE
First commit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+## Example
+
+```tf
+module "postgres_waterhose-admin" {
+  source           = "github.com/dapperlabs-platform/terraform-postgres-grants?ref={ref}"
+  database         = "the-database"
+  role             = "the-database-role"
+  tables           = ["tables", "go", "here]
+  table_privileges = ["SELECT", "INSERT", "UPDATE", "DELETE"]
+  users            = ["example@dapperlabs.com"]
+}
+```
+
 ## Requirements
 
 | Name | Version |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_postgresql"></a> [postgresql](#requirement\_postgresql) | 1.19.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_postgresql"></a> [postgresql](#provider\_postgresql) | 1.19.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [postgresql_grant.database_grant](https://registry.terraform.io/providers/cyrilgdn/postgresql/1.19.0/docs/resources/grant) | resource |
+| [postgresql_grant.table_grant](https://registry.terraform.io/providers/cyrilgdn/postgresql/1.19.0/docs/resources/grant) | resource |
+| [postgresql_grant_role.user_role_grant_role](https://registry.terraform.io/providers/cyrilgdn/postgresql/1.19.0/docs/resources/grant_role) | resource |
+| [postgresql_role.the_role](https://registry.terraform.io/providers/cyrilgdn/postgresql/1.19.0/docs/resources/role) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_database"></a> [database](#input\_database) | Database this applies to | `string` | n/a | yes |
+| <a name="input_database_privileges"></a> [database\_privileges](#input\_database\_privileges) | Privileges to apply to the database | `list(string)` | <pre>[<br>  "CONNECT"<br>]</pre> | no |
+| <a name="input_role"></a> [role](#input\_role) | Name of the role to create | `string` | n/a | yes |
+| <a name="input_schema"></a> [schema](#input\_schema) | Table schema | `string` | `"public"` | no |
+| <a name="input_table_privileges"></a> [table\_privileges](#input\_table\_privileges) | Privileges to apply to tables in the database | `list(string)` | n/a | yes |
+| <a name="input_tables"></a> [tables](#input\_tables) | Tables in the database | `list(string)` | n/a | yes |
+| <a name="input_users"></a> [users](#input\_users) | Users who need access to the database and tables | `list(string)` | n/a | yes |
+
+## Outputs
+
+No outputs.

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,25 @@
+resource "postgresql_role" "the_role" {
+  name = var.role
+}
+
+resource "postgresql_grant" "database_grant" {
+  database    = var.database
+  role        = postgresql_role.the_role.name
+  object_type = "database"
+  privileges  = var.database_privileges
+}
+
+resource "postgresql_grant" "table_grant" {
+  database    = var.database
+  role        = postgresql_role.the_role.name
+  schema      = var.schema
+  object_type = "table"
+  objects     = var.tables
+  privileges  = var.table_privileges
+}
+
+resource "postgresql_grant_role" "user_role_grant_role" {
+  for_each   = toset(var.users)
+  role       = each.key
+  grant_role = postgresql_role.the_role.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,36 @@
+variable "role" {
+  description = "Name of the role to create"
+  type        = string
+}
+
+variable "database" {
+  description = "Database this applies to"
+  type        = string
+}
+
+variable "schema" {
+  description = "Table schema"
+  type        = string
+  default     = "public"
+}
+
+variable "table_privileges" {
+  description = "Privileges to apply to tables in the database"
+  type        = list(string)
+}
+
+variable "database_privileges" {
+  description = "Privileges to apply to the database"
+  type        = list(string)
+  default     = ["CONNECT"]
+}
+
+variable "tables" {
+  description = "Tables in the database"
+  type        = list(string)
+}
+
+variable "users" {
+  description = "Users who need access to the database and tables"
+  type        = list(string)
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+      version = "1.19.0"
+    }
+  }
+}


### PR DESCRIPTION
Want a better way to do this - with less steps.

Here's what I tested:

```tf
module "postgres_waterhose-admin" {
  source           = "github.com/dapperlabs-platform/terraform-postgres-grants?ref=first-commit"
  database         = "waterhose-db"
  role             = "waterhose-admin"
  tables           = ["eventclient_outbox", "waterhose_block_cursor", "waterhose_transactions"]
  table_privileges = ["SELECT", "INSERT", "UPDATE", "DELETE"]
  users            = ["darron.froese@dapperlabs.com"]
}
```

Here's the plan:

```tf
Success! The configuration is valid.



Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
+ create

Terraform will perform the following actions:

  # module.postgres_waterhose-admin.postgresql_grant.database_grant will be created
+ resource "postgresql_grant" "database_grant" {
      + database          = "waterhose-db"
      + id                = (known after apply)
      + object_type       = "database"
      + privileges        = [
          + "CONNECT",
        ]
      + role              = "waterhose-admin"
      + with_grant_option = false
    }

  # module.postgres_waterhose-admin.postgresql_grant.table_grant will be created
+ resource "postgresql_grant" "table_grant" {
      + database          = "waterhose-db"
      + id                = (known after apply)
      + object_type       = "table"
      + objects           = [
          + "eventclient_outbox",
          + "waterhose_block_cursor",
          + "waterhose_transactions",
        ]
      + privileges        = [
          + "DELETE",
          + "INSERT",
          + "SELECT",
          + "UPDATE",
        ]
      + role              = "waterhose-admin"
      + schema            = "public"
      + with_grant_option = false
    }

  # module.postgres_waterhose-admin.postgresql_grant_role.user_role_grant_role["darron.froese@dapperlabs.com"] will be created
+ resource "postgresql_grant_role" "user_role_grant_role" {
      + grant_role        = "waterhose-admin"
      + id                = (known after apply)
      + role              = "darron.froese@dapperlabs.com"
      + with_admin_option = false
    }

  # module.postgres_waterhose-admin.postgresql_role.the_role will be created
+ resource "postgresql_role" "the_role" {
      + bypass_row_level_security = false
      + connection_limit          = -1
      + create_database           = false
      + create_role               = false
      + encrypted_password        = true
      + id                        = (known after apply)
      + inherit                   = true
      + login                     = false
      + name                      = "waterhose-admin"
      + replication               = false
      + skip_drop_role            = false
      + skip_reassign_owned       = false
      + superuser                 = false
      + valid_until               = "infinity"
    }

Plan: 4 to add, 0 to change, 0 to destroy.
```