### PR TITLE
Allow the ability to grant default table privileges

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -14,8 +14,14 @@ variable "schema" {
   default     = "public"
 }
 
+variable "default_table_privileges" {
+  description = "Default privileges to apply to all tables in the database"
+  type        = list(string)
+  default     = []
+}
+
 variable "table_privileges" {
-  description = "Privileges to apply to tables in the database"
+  description = "Privileges to apply to specified tables (variable) in the database"
   type        = list(string)
 }
 
@@ -28,9 +34,16 @@ variable "database_privileges" {
 variable "tables" {
   description = "Tables in the database"
   type        = list(string)
+  default     = []
 }
 
 variable "users" {
   description = "Users who need access to the database and tables"
   type        = list(string)
+}
+
+variable "owner" {
+  description = "Schema owner, for granting default privileges"
+  type        = string
+  default     = "postgres"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,7 @@ variable "default_table_privileges" {
 variable "table_privileges" {
   description = "Privileges to apply to specified tables (variable) in the database"
   type        = list(string)
+  default     = []
 }
 
 variable "database_privileges" {

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     postgresql = {
       source  = "cyrilgdn/postgresql"
-      version = "1.19.0"
+      version = "1.22.0"
     }
   }
 }


### PR DESCRIPTION
We want to allow the ability to grant default privileges in addition to specific table privileges.  This is useful to allow read only for all tables, but update for specific others, or to just grant a privilege across all tables for development.